### PR TITLE
Fix card buttons layout

### DIFF
--- a/src/modules/specimens/components/specimens-components/SpecimenCard.tsx
+++ b/src/modules/specimens/components/specimens-components/SpecimenCard.tsx
@@ -91,7 +91,11 @@ const SpecimenCard: React.FC<SpecimenCardProps> = ({
         subtitle={headerProps.subtitle}
         headerAction={headerProps.headerAction}
         footer={
-          <div className="flex flex-wrap justify-between items-center w-full gap-2">
+          <div className="flex flex-col items-center w-full gap-2">
+            <SpecimenCardFooter
+              specimenId={specimen.id}
+              onDelete={onDelete}
+            />
             <Button
               variant="secondary"
               size="small"
@@ -103,10 +107,6 @@ const SpecimenCard: React.FC<SpecimenCardProps> = ({
               </svg>
               Изображение
             </Button>
-            <SpecimenCardFooter 
-              specimenId={specimen.id} 
-              onDelete={onDelete} 
-            />
           </div>
         }
         onClick={isClickable ? handleCardClick : undefined}

--- a/src/modules/specimens/components/specimens-components/card-parts/SpecimenCardFooter.tsx
+++ b/src/modules/specimens/components/specimens-components/card-parts/SpecimenCardFooter.tsx
@@ -11,7 +11,7 @@ export const SpecimenCardFooter: React.FC<SpecimenCardFooterProps> = ({
   onDelete 
 }) => {
   return (
-    <div className="flex justify-end items-center flex-wrap gap-2 opacity-90 hover:opacity-100 transition-opacity">
+    <div className="flex justify-center items-center flex-wrap gap-2 w-full opacity-90 hover:opacity-100 transition-opacity">
       <ActionButtons specimenId={specimenId} onDelete={onDelete} variant="card" />
     </div>
   );

--- a/src/modules/specimens/components/specimens-controls/ActionButtons.tsx
+++ b/src/modules/specimens/components/specimens-controls/ActionButtons.tsx
@@ -45,7 +45,7 @@ const ActionButtons: React.FC<ActionButtonsProps> = ({
   
   const containerClass =
     variant === 'card'
-      ? 'justify-end items-center flex-wrap gap-x-3 gap-y-2'
+      ? 'justify-center items-center flex-wrap gap-2 w-full'
       : 'justify-end items-center space-x-1';
 
   return (
@@ -55,7 +55,7 @@ const ActionButtons: React.FC<ActionButtonsProps> = ({
           variant="neutral"
           size="small"
           onClick={handleEditClick}
-          className={`flex items-center ${variant === 'card' ? '!px-3 py-1.5' : '!p-1.5'} rounded-md shadow-sm hover:shadow-md group ${animationClasses.transition}`}
+          className={`flex items-center ${variant === 'card' ? '!px-3 py-1.5 flex-1' : '!p-1.5'} rounded-md shadow-sm hover:shadow-md group ${animationClasses.transition}`}
         >
           <svg className="w-4 h-4 mr-1.5 text-blue-600 group-hover:text-blue-700" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
@@ -67,7 +67,7 @@ const ActionButtons: React.FC<ActionButtonsProps> = ({
           variant="neutral"
           size="small"
           onClick={handleDeleteClick}
-          className={`flex items-center ${variant === 'card' ? '!px-3 py-1.5' : '!p-1.5'} rounded-md shadow-sm hover:shadow-md group ${animationClasses.transition}`}
+          className={`flex items-center ${variant === 'card' ? '!px-3 py-1.5 flex-1' : '!p-1.5'} rounded-md shadow-sm hover:shadow-md group ${animationClasses.transition}`}
         >
           <svg className="w-4 h-4 mr-1.5 text-red-500 group-hover:text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />


### PR DESCRIPTION
## Summary
- center the "Edit"/"Delete" button group inside specimen cards
- stack the image button below the action buttons

## Testing
- `npm test` *(fails: craco not found)*

------
https://chatgpt.com/codex/tasks/task_e_684417367d8883328c3942a0ace075b1