### PR TITLE
Improve specimens performance and modals

### DIFF
--- a/src/modules/specimens/components/specimens-components/SpecimenCard.tsx
+++ b/src/modules/specimens/components/specimens-components/SpecimenCard.tsx
@@ -84,9 +84,9 @@ const SpecimenCard: React.FC<SpecimenCardProps> = ({
   const buttonClass = getUnifiedButtonClasses('card');
   
   return (
-    <>
+    <div className="relative">
       <Card
-        className={`relative flex flex-col h-full ${animationClasses.transition} group overflow-hidden
+        className={`flex flex-col h-full ${animationClasses.transition} group overflow-hidden
           hover:shadow-lg ${isClickable ? 'cursor-pointer' : ''}`}
         contentClassName="flex-grow"
         headerClassName={headerProps.headerClassName}
@@ -175,7 +175,7 @@ const SpecimenCard: React.FC<SpecimenCardProps> = ({
           </div>
         </div>
       </Modal>
-    </>
+    </div>
   );
 };
 

--- a/src/modules/specimens/components/specimens-components/SpecimenCard.tsx
+++ b/src/modules/specimens/components/specimens-components/SpecimenCard.tsx
@@ -87,7 +87,7 @@ const SpecimenCard: React.FC<SpecimenCardProps> = ({
     <>
       <Card
         className={`relative flex flex-col h-full ${animationClasses.transition} group overflow-hidden
-          hover:shadow-lg hover:border-[#0A84FF]/20 ${isClickable ? 'cursor-pointer' : ''}`}
+          hover:shadow-lg ${isClickable ? 'cursor-pointer' : ''}`}
         contentClassName="flex-grow"
         headerClassName={headerProps.headerClassName}
         title={headerProps.title}
@@ -155,7 +155,7 @@ const SpecimenCard: React.FC<SpecimenCardProps> = ({
         <div className="flex flex-col items-center p-2">
           <div className="w-full max-h-[70vh] overflow-hidden rounded-lg">
             {isLoading ? (
-              <div className="w-full h-64 flex items-center justify-center bg-gray-100">
+              <div className="w-full h-[70vh] flex items-center justify-center bg-gray-100">
                 <span className="text-gray-500">Загрузка изображения...</span>
               </div>
             ) : (

--- a/src/modules/specimens/components/specimens-components/SpecimenCard.tsx
+++ b/src/modules/specimens/components/specimens-components/SpecimenCard.tsx
@@ -86,7 +86,7 @@ const SpecimenCard: React.FC<SpecimenCardProps> = ({
   return (
     <>
       <Card
-        className={`flex flex-col h-full ${animationClasses.transition} group overflow-hidden
+        className={`relative flex flex-col h-full ${animationClasses.transition} group overflow-hidden
           hover:shadow-lg hover:border-[#0A84FF]/20 ${isClickable ? 'cursor-pointer' : ''}`}
         contentClassName="flex-grow"
         headerClassName={headerProps.headerClassName}
@@ -149,7 +149,8 @@ const SpecimenCard: React.FC<SpecimenCardProps> = ({
         size="medium"
         variant="elevated"
         animation="fade"
-        blockScroll={true}
+        blockScroll={false}
+        usePortal={false}
       >
         <div className="flex flex-col items-center p-2">
           <div className="w-full max-h-[70vh] overflow-hidden rounded-lg">

--- a/src/modules/specimens/components/specimens-components/SpecimenCard.tsx
+++ b/src/modules/specimens/components/specimens-components/SpecimenCard.tsx
@@ -178,4 +178,4 @@ const SpecimenCard: React.FC<SpecimenCardProps> = ({
   );
 };
 
-export default SpecimenCard; 
+export default React.memo(SpecimenCard);

--- a/src/modules/specimens/components/specimens-components/SpecimenRow.tsx
+++ b/src/modules/specimens/components/specimens-components/SpecimenRow.tsx
@@ -63,4 +63,4 @@ const SpecimenRow: React.FC<SpecimenRowProps> = ({
   );
 };
 
-export default SpecimenRow; 
+export default React.memo(SpecimenRow);

--- a/src/modules/specimens/components/specimens-components/SpecimensGrid.tsx
+++ b/src/modules/specimens/components/specimens-components/SpecimensGrid.tsx
@@ -51,4 +51,4 @@ const SpecimensGrid: React.FC<SpecimensGridProps> = ({
   );
 };
 
-export default SpecimensGrid; 
+export default React.memo(SpecimensGrid);

--- a/src/modules/specimens/components/specimens-components/SpecimensGrid.tsx
+++ b/src/modules/specimens/components/specimens-components/SpecimensGrid.tsx
@@ -38,7 +38,7 @@ const SpecimensGrid: React.FC<SpecimensGridProps> = ({
   return (
     <div className={`${layoutClasses.grid4.replace('gap-6', 'gap-8')} ${animationClasses.fadeIn}`}>
       {specimens.map((specimen) => (
-        <div key={specimen.id} className={`${animationClasses.transition} ${animationClasses.springHover} h-full`}> 
+        <div key={specimen.id} className={`${animationClasses.transition} h-full`}>
           <SpecimenCard
             specimen={specimen}
             getSectorTypeName={getSectorTypeName}

--- a/src/modules/specimens/components/specimens-components/SpecimensTable.tsx
+++ b/src/modules/specimens/components/specimens-components/SpecimensTable.tsx
@@ -71,10 +71,10 @@ const SpecimensTable: React.FC<SpecimensTableProps> = ({
   ];
 
   return (
-    <div className={`${cardClasses.elevated} backdrop-blur-lg overflow-hidden rounded-xl border border-[#E5E5EA]/80 ${animationClasses.transition}`}>
+    <div className={`${cardClasses.elevated} overflow-hidden rounded-xl border border-[#E5E5EA]/80 ${animationClasses.transition}`}>
       <div className="overflow-x-auto">
         <table className="min-w-full divide-y divide-[#E5E5EA]">
-          <thead className="bg-[#F5F5F7]/80 backdrop-filter backdrop-blur-sm">
+          <thead className="bg-[#F5F5F7]/80">
             <tr>
               {tableHeaders.map((header) => (
                 <th 
@@ -96,7 +96,7 @@ const SpecimensTable: React.FC<SpecimensTableProps> = ({
               ))}
             </tr>
           </thead>
-          <tbody className="bg-white/80 backdrop-filter backdrop-blur-sm divide-y divide-[#E5E5EA]">
+          <tbody className="bg-white/80 divide-y divide-[#E5E5EA]">
             {specimensWithFamilies.length > 0 ? (
               specimensWithFamilies.map((specimen) => (
                 <SpecimenRow
@@ -120,4 +120,4 @@ const SpecimensTable: React.FC<SpecimensTableProps> = ({
   );
 };
 
-export default SpecimensTable; 
+export default React.memo(SpecimensTable);

--- a/src/modules/ui/components/Card.tsx
+++ b/src/modules/ui/components/Card.tsx
@@ -43,7 +43,7 @@ const Card: React.FC<CardProps> = ({
     : cardClasses.elevated;
     
   // Классы для основного контейнера
-  const containerClasses = `${baseClass} ${variantClass} ${className} ${onClick ? 'cursor-pointer transition-transform hover:-translate-y-1' : ''}`;
+  const containerClasses = `${baseClass} ${variantClass} ${className} ${onClick ? 'cursor-pointer transition-shadow duration-300' : ''}`;
   
   // Классы для содержимого
   const contentClasses = `${cardClasses.content} ${contentClassName}`;

--- a/src/modules/ui/components/Modal.tsx
+++ b/src/modules/ui/components/Modal.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import ReactDOM from 'react-dom';
 import { cardClasses } from '../../../styles/global-styles';
 
 export interface ModalProps {
@@ -210,8 +211,8 @@ const Modal: React.FC<ModalProps> = ({
     opacity: isOpen ? 1 : 0 
   } : {};
   
-  return (
-    <div 
+  const modalContent = (
+    <div
       className={`fixed inset-0 z-[9999] flex items-center justify-center p-4 bg-black/40 transition-all duration-300 ${
         isOpen ? 'opacity-100' : 'opacity-0'
       }`}
@@ -220,7 +221,7 @@ const Modal: React.FC<ModalProps> = ({
       aria-modal="true"
       style={{ pointerEvents: 'all' }}
     >
-      <div 
+      <div
         ref={modalRef}
         className={modalClasses}
         onClick={(e) => e.stopPropagation()}
@@ -269,6 +270,8 @@ const Modal: React.FC<ModalProps> = ({
       </div>
     </div>
   );
+
+  return ReactDOM.createPortal(modalContent, document.body);
 };
 
 export default Modal; 

--- a/src/modules/ui/components/Modal.tsx
+++ b/src/modules/ui/components/Modal.tsx
@@ -67,7 +67,11 @@ export interface ModalProps {
    * Блокировать ли прокрутку страницы при открытии модального окна
    */
   blockScroll?: boolean;
-}
+  /**
+   * Рендерить модалку через портал в body
+   */
+  usePortal?: boolean;
+  }
 
 /**
  * Универсальный компонент модального окна.
@@ -89,7 +93,8 @@ const Modal: React.FC<ModalProps> = ({
   showCloseButton = true,
   verticalPosition = 'center',
   animation = 'fade',
-  blockScroll = false
+  blockScroll = false,
+  usePortal = true
 }) => {
   const [isVisible, setIsVisible] = useState(false);
   const modalRef = useRef<HTMLDivElement>(null);
@@ -213,7 +218,7 @@ const Modal: React.FC<ModalProps> = ({
   
   const modalContent = (
     <div
-      className={`fixed inset-0 z-[9999] flex items-center justify-center p-4 bg-black/40 transition-all duration-300 ${
+      className={`${usePortal ? 'fixed' : 'absolute'} inset-0 z-[9999] flex items-center justify-center p-4 bg-black/40 transition-all duration-300 ${
         isOpen ? 'opacity-100' : 'opacity-0'
       }`}
       onClick={handleOverlayClick}
@@ -271,7 +276,7 @@ const Modal: React.FC<ModalProps> = ({
     </div>
   );
 
-  return ReactDOM.createPortal(modalContent, document.body);
+  return usePortal ? ReactDOM.createPortal(modalContent, document.body) : modalContent;
 };
 
 export default Modal; 

--- a/src/pages/specimens/SpecimensListPage.tsx
+++ b/src/pages/specimens/SpecimensListPage.tsx
@@ -127,7 +127,7 @@ const SpecimensListPage: React.FC = () => {
 
           {/* Индикатор загрузки */}
           {loading && sortedAndFilteredSpecimens.length > 0 && (
-            <div className="absolute inset-0 bg-white/50 backdrop-blur-sm flex items-center justify-center">
+            <div className="absolute inset-0 bg-white/50 flex items-center justify-center">
               <SpecimensLoading fullScreen={false} />
             </div>
           )}


### PR DESCRIPTION
## Summary
- use React.memo for specimen cards, rows, grid and table for smoother list page
- remove unused blur effect from specimens table
- render modal content through portal to simplify overlay behavior

## Testing
- `npm test --silent` *(fails: craco not found)*

------
https://chatgpt.com/codex/tasks/task_e_68441b78b4308332a293200fa0d389ae