### PR TITLE
Remove MapProvider wrapper around MapPage

### DIFF
--- a/src/routes/mapRoutes.tsx
+++ b/src/routes/mapRoutes.tsx
@@ -2,10 +2,9 @@ import React from 'react';
 import { RouteObject } from 'react-router-dom';
 import { ProtectedRoute } from '../modules/auth/components/ProtectedRoute';
 import { MainLayout } from '../modules/layouts';
-import { 
-  MapPage, 
-  MapProvider, 
-  useMapConfig, 
+import {
+  MapPage,
+  useMapConfig,
   MAP_LAYERS,
   MAP_MODES,
   DEFAULT_MAP_CONFIG,
@@ -24,12 +23,10 @@ export const mapRoutes: RouteObject[] = [
     element: (
       <ProtectedRoute>
         <MainLayout>
-          <MapProvider>
-            <MapPage 
-              showControls={true}
-              extraControls={<UnifiedControlPanel pageType="map" />}
-            />
-          </MapProvider>
+          <MapPage
+            showControls={true}
+            extraControls={<UnifiedControlPanel pageType="map" />}
+          />
         </MainLayout>
       </ProtectedRoute>
     ),
@@ -39,12 +36,10 @@ export const mapRoutes: RouteObject[] = [
     element: (
       <ProtectedRoute>
         <MainLayout>
-          <MapProvider>
-            <MapPage 
-              showControls={true}
-              extraControls={<UnifiedControlPanel pageType="sector" />}
-            />
-          </MapProvider>
+          <MapPage
+            showControls={true}
+            extraControls={<UnifiedControlPanel pageType="sector" />}
+          />
         </MainLayout>
       </ProtectedRoute>
     ),


### PR DESCRIPTION
## Summary
- stop wrapping `MapPage` in `MapProvider`
- `MapPage` already sets up its own provider

## Testing
- `npm test` *(fails: craco not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848094526e083328db02e811b44a0f6