### PR TITLE
Fix map config initialization

### DIFF
--- a/src/modules/map/components/MapPage.tsx
+++ b/src/modules/map/components/MapPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import 'leaflet/dist/leaflet.css';
 import { MapConfigProvider } from '../contexts/MapConfigContext';
 import { MapProvider } from '../contexts/MapContext';
@@ -30,9 +30,11 @@ const MapPage: React.FC<MapPageProps & { mode?: 'full' | 'light' }> = ({
   ...contentProps
 }) => {
   // Выбираем конфигурацию в зависимости от режима
-  const config = mode === 'light' 
-    ? { ...LIGHT_CONFIG, ...initialConfig }
-    : initialConfig;
+  const config = useMemo(() => (
+    mode === 'light'
+      ? { ...LIGHT_CONFIG, ...initialConfig }
+      : initialConfig
+  ), [mode, initialConfig]);
 
   return (
     <MapConfigProvider initialConfig={config}>

--- a/src/modules/map/contexts/MapConfigContext.tsx
+++ b/src/modules/map/contexts/MapConfigContext.tsx
@@ -120,9 +120,10 @@ interface MapConfigProviderProps {
 }
 
 export const MapConfigProvider: React.FC<MapConfigProviderProps> = ({ children, initialConfig }) => {
+  const initialConfigRef = React.useRef(initialConfig);
   const [mapConfig, setMapConfig] = useState<MapConfig>({
     ...DEFAULT_MAP_CONFIG,
-    ...initialConfig
+    ...initialConfigRef.current
   });
 
   useEffect(() => {
@@ -134,7 +135,7 @@ export const MapConfigProvider: React.FC<MapConfigProviderProps> = ({ children, 
         setMapConfig(prevConfig => ({
           ...prevConfig,
           ...parsedConfig,
-          ...initialConfig
+          ...initialConfigRef.current
         }));
       } else {
         console.log('[MapConfig] Конфигурация в localStorage не найдена, используется по умолчанию.');
@@ -142,7 +143,7 @@ export const MapConfigProvider: React.FC<MapConfigProviderProps> = ({ children, 
     } catch (error) {
       console.error('Ошибка при загрузке конфигурации карты:', error);
     }
-  }, [initialConfig]);
+  }, []);
   
   useEffect(() => {
     if (mapConfig.drawingEnabled) {


### PR DESCRIPTION
## Summary
- keep `config` stable in MapPage
- load map settings from storage only once and keep runtime updates

## Testing
- `npm test --silent` *(fails: craco not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848095b42488332a329592a59f4c079