### PR TITLE
Improve map page layout

### DIFF
--- a/src/modules/map/components/MapPageContent.tsx
+++ b/src/modules/map/components/MapPageContent.tsx
@@ -66,7 +66,7 @@ const MapPageContent: React.FC<MapPageContentProps> = ({
   }, [customLayers]);
     
   return (
-    <div className="w-full h-full flex justify-center items-center pt-8 mt-4">
+    <div className="w-full flex justify-center items-center min-h-[calc(100vh-64px)]">
       <div className="w-full max-w-10xl">
         <MapCard 
           title={mapTitle}

--- a/src/modules/map/styles/index.ts
+++ b/src/modules/map/styles/index.ts
@@ -12,7 +12,7 @@ import 'leaflet.markercluster/dist/MarkerCluster.Default.css';
 export const MAP_STYLES = {
   // Tailwind классы для карты
   mapContainer: 'w-full h-full flex flex-col shadow-lg rounded-lg overflow-hidden bg-white',
-  mapContent: 'w-full h-[810px] relative rounded-b-lg overflow-hidden backdrop-blur-md',
+  mapContent: 'w-full h-[calc(100vh-8rem)] relative rounded-b-lg overflow-hidden backdrop-blur-md',
   
   // Классы для панели управления
   controlPanel: 'p-4 bg-white/95 backdrop-blur rounded-t-lg border-b border-neutral-dark/20 shadow-sm',


### PR DESCRIPTION
## Summary
- center the map container and remove extra spacing
- make map content fill available viewport height

## Testing
- `npm test --silent --maxWorkers=2` *(fails: craco not found)*

------
https://chatgpt.com/codex/tasks/task_e_684996f83dec83329465e7e42375b3ca