### PR TITLE
Fix map card height

### DIFF
--- a/src/modules/map/components/MapPageContent.tsx
+++ b/src/modules/map/components/MapPageContent.tsx
@@ -66,8 +66,8 @@ const MapPageContent: React.FC<MapPageContentProps> = ({
   }, [customLayers]);
     
   return (
-    <div className="w-full h-full flex justify-center items-center pt-8 mt-4">
-      <div className="w-full max-w-10xl">
+    <div className="w-full flex justify-center items-center min-h-[calc(100vh-64px)]">
+      <div className="w-full max-w-10xl h-full">
         <MapCard 
           title={mapTitle}
           loading={loading}

--- a/src/modules/map/components/map-card/MapCard.tsx
+++ b/src/modules/map/components/map-card/MapCard.tsx
@@ -12,7 +12,8 @@ const MapCard: React.FC<MapCardProps> = ({ title, loading = false, children }) =
       title={title}
       headerAction={loading && <LoadingSpinner size="small" message="" />}
       variant="elevated"
-      contentClassName="p-0"
+      className="h-full flex flex-col"
+      contentClassName="p-0 flex-1"
     >
       <div className={MAP_STYLES.mapContent}>
         {children}

--- a/src/modules/map/styles/index.ts
+++ b/src/modules/map/styles/index.ts
@@ -12,7 +12,7 @@ import 'leaflet.markercluster/dist/MarkerCluster.Default.css';
 export const MAP_STYLES = {
   // Tailwind классы для карты
   mapContainer: 'w-full h-full flex flex-col shadow-lg rounded-lg overflow-hidden bg-white',
-  mapContent: 'w-full h-[810px] relative rounded-b-lg overflow-hidden backdrop-blur-md',
+  mapContent: 'w-full h-full min-h-[calc(100vh-64px)] relative rounded-b-lg overflow-hidden backdrop-blur-md',
   
   // Классы для панели управления
   controlPanel: 'p-4 bg-white/95 backdrop-blur rounded-t-lg border-b border-neutral-dark/20 shadow-sm',


### PR DESCRIPTION
## Summary
- make map card height flexible
- center the map and stretch to viewport
- keep container dynamic height in map styles

## Testing
- `npm test` *(fails: craco not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849987b56c88332970bdd413649cdad