### PR TITLE
Fix quick dismiss bug in notifications

### DIFF
--- a/src/modules/notifications/components/NotificationItem.tsx
+++ b/src/modules/notifications/components/NotificationItem.tsx
@@ -15,23 +15,33 @@ const NotificationItem: React.FC<NotificationItemProps> = ({ notification }) => 
 
   // Определяем функцию handleDismiss перед использованием в useEffect
   const handleDismiss = useCallback(() => {
+    // Если уведомление ещё не успело появиться, сразу удаляем его
+    if (!isVisible) {
+      removeNotification(id);
+      return;
+    }
+
     setIsExiting(true);
-    
+
     // Регистрируем слушатель события окончания анимации
     if (elementRef.current) {
-      elementRef.current.addEventListener('transitionend', (e) => {
+      const onTransitionEnd = (e: TransitionEvent) => {
         if (e.propertyName === 'opacity' || e.propertyName === 'transform') {
-          // Удаляем после завершения анимации
           removeNotification(id);
         }
-      }, { once: true });
+      };
+
+      elementRef.current.addEventListener('transitionend', onTransitionEnd, { once: true });
+
+      // Подстраховка на случай, если transitionend не сработает
+      setTimeout(() => removeNotification(id), 350);
     } else {
       // Запасной вариант, если что-то пошло не так с анимацией
       setTimeout(() => {
         removeNotification(id);
       }, 300);
     }
-  }, [id, removeNotification]);
+  }, [id, removeNotification, isVisible]);
 
   // Используем один эффект для установки видимости с небольшой задержкой
   useEffect(() => {


### PR DESCRIPTION
## Summary
- ensure clicking close before animation starts removes the notification

## Testing
- `npm test --silent -- --watchAll=false` *(fails: `craco` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c1bba8edc8332b8a8c8561af5402c